### PR TITLE
fix(javascript): ajout de la dépendance à coffee

### DIFF
--- a/lib/raindrops/engine.rb
+++ b/lib/raindrops/engine.rb
@@ -7,6 +7,7 @@ module Raindrops #:nodoc:
     require 'jquery-rails'
     require 'bootstrap-sass'
     require 'sass-rails'
+	require 'coffee-rails'
 
     initializer 'raindrops' do |app|
       app.config.cache_store = :memory_store, { size: 8.megabytes }

--- a/raindrops.gemspec
+++ b/raindrops.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'jquery-rails', '~> 4.0.5'
   s.add_dependency 'bootstrap-sass', '~> 3.3.5'
   s.add_dependency 'sass-rails', '>= 3.2'
+  s.add_dependency 'coffee-rails'
 end


### PR DESCRIPTION
sans cette dépendance le fichier .coffee ne peut pas être compilé et cela provoque donc des 500

refs #8